### PR TITLE
Conditional aes support

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,16 +11,6 @@ use Alien::Sodium ();
 use Alien::Base::Wrapper ();
 use Devel::CheckLib qw(check_lib);
 
-sub has_aes256gcm {
-    return check_lib(
-        debug => 0,
-        function => 'return !(!sodium_init() && crypto_aead_aes256gcm_is_available());',
-        LIBS => Alien::Sodium->libs,
-        ccflags => Alien::Sodium->cflags(),
-        header => 'sodium.h',
-    );
-}
-
 sub has_aes128ctr {
     return check_lib(
         debug => 0,
@@ -32,7 +22,6 @@ sub has_aes128ctr {
 }
 
 my @defines;
-push @defines, 'AES256GCM_IS_AVAILABLE' if has_aes256gcm();
 push @defines, 'AES128CTR_IS_AVAILABLE' if has_aes128ctr();
 my %xsbuild = Alien::Base::Wrapper->new('Alien::Sodium')->mm_args2(
     "DEFINE" => join(" ", map { "-D$_" } @defines),

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,23 +9,8 @@ use ExtUtils::MakeMaker;
 
 use Alien::Sodium ();
 use Alien::Base::Wrapper ();
-use Devel::CheckLib qw(check_lib);
 
-sub has_aes128ctr {
-    return check_lib(
-        debug => 0,
-        function => 'sodium_init(); return crypto_stream_aes128ctr_NONCEBYTES ? 0 : 1;',
-        LIBS => Alien::Sodium->libs,
-        ccflags => Alien::Sodium->cflags(),
-        header => 'sodium.h',
-    );
-}
-
-my @defines;
-push @defines, 'AES128CTR_IS_AVAILABLE' if has_aes128ctr();
-my %xsbuild = Alien::Base::Wrapper->new('Alien::Sodium')->mm_args2(
-    "DEFINE" => join(" ", map { "-D$_" } @defines),
-);
+my %xsbuild = Alien::Base::Wrapper->new('Alien::Sodium');
 # use Data::Dumper;
 # print Dumper(\%xsbuild);
 # exit(1);

--- a/Sodium.xs
+++ b/Sodium.xs
@@ -11,6 +11,10 @@
 /* libsodium */
 #include "sodium.h"
 
+#ifdef crypto_stream_aes128ctr_NONCEBYTES
+#define AES128CTR_IS_AVAILABLE 1
+#endif
+
 #define DUMP(v) do_sv_dump(0, Perl_debug_log, v, 0, 4, 0, 0);
 
 static int has_aes256gcm;


### PR DESCRIPTION
hey, i saw you were working on this (condolences), so here's a couple suggestions.

the aes128ctr stuff is just to remove a (pre-existing) rube goldberg-esque way of doing the exact same thing. there's really no need to even do as here (ifdef thing1 define thing2 ... ifdef thing2 ...), but i left it this way for minimal change and a bit of clarity.

the aes256gcm stuff is slightly more interesting. a user may change hardware or ship around pre-compiled code, or similarly a distribution may want to package and distribute this dist. doing the cpu flag checks at runtime would be important in those cases. keeping a separate static var indicating the support versus just calling `crypto_aead_aesgcm256_is_availabile()` everywhere probably makes little difference...libsodium just keeps the cpu flag check in a statically anyway.

hope it helps!